### PR TITLE
fix the filename pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In addition, you can also set the filetype by reading shebangs, which might be u
 -- see `:h vim.filetype.add()`
 vim.filetype.add({
   pattern = {
-    ["*"] = {
+    [".*"] = {
       priority = -math.huge,
       function(path, bufnr)
         local content = vim.filetype.getlines(bufnr, 1)


### PR DESCRIPTION
hello there :yum: 

i've tried to add your snippet to detect `nu` files based on their sheband but it did not work...

i think i found the fix, which is to match the filenames with `.*` and not `*` :smirk: 